### PR TITLE
Removed extraneous lbracket that was throwing FutureWarnings

### DIFF
--- a/pourover/functions.py
+++ b/pourover/functions.py
@@ -20,7 +20,7 @@ from .models import CEFMessage, CEFLog
 # regular expressions needed for parsing, kept out of the functions for ease of reading
 HEADER_SEP = r'(.*(?<!\\)\|){,7}(.*)'
 HEADER_SPLIT = r'(?<!\\)\|'
-SYSLOG_SEP = r'[a-zA-Z]{3}\s+[0-9]{,2}\s(?:[[0-9]{2}:*){3}\s+\w+'
+SYSLOG_SEP = r'[a-zA-Z]{3}\s+[0-9]{,2}\s(?:[0-9]{2}:*){3}\s+\w+'
 EXTENSION_MATCH = r'([^=\s]+)=((?:[\\]=|[^=])+)(?:\s|$)'
 
 


### PR DESCRIPTION
Fixes: #23 

Ended up being an extraneous lbracket in the range used to pull groups of two digits from each part of the timestamp - this wasn't causing issues, since it was purely additive to the needed `[0-9]`, but was raising red flags with the code checking for nested sets (an open `[` anywhere within an existing set, evidently).